### PR TITLE
Use prefix supplied via configure script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+.svn
+
+# Apple cruft
+.DS_Store
+._*
+
+# temporary/swap files (VIM etc.)
+*~
+*.sw[op]
+
 # Object files
 *.o
 *.ko
@@ -5,14 +15,12 @@
 *.elf
 
 # Precompiled Headers
-*.gch
-*.pch
+*.[gp]ch
 
 # Libraries
 *.lib
 *.a
-*.la
-*.lo
+*.l[ao]
 
 # Shared objects (inc. Windows DLLs)
 *.dll
@@ -24,11 +32,11 @@
 *.exe
 *.out
 *.app
-*.i*86
+*.i?86
 *.x86_64
 *.hex
 
-# ac
+# Autoconf/Automake
 *autom4te.cache
 src/aclocal.m4
 src/compile
@@ -40,10 +48,32 @@ src/config.log
 src/config.status
 src/Makefile
 
-# editor mess
-*~
-
 # genesis mess
+*@.[chg]
 src/liblist
-**/*@.*
+src/files
+src/loadlib.c
+src/convert/lex.yy.c
+src/convert/y.*
 
+# netcdf temporary files
+src/diskio/interface/netcdf/netcdflib
+src/diskio/interface/netcdf/netcdf-3.4/src/libsrc/ncconfig.h
+src/diskio/interface/netcdf/netcdf-3.4/src/libsrc/ncx.c
+src/diskio/interface/netcdf/netcdf-3.4/src/libsrc/putget.c
+src/diskio/interface/netcdf/netcdf-3.4/src/config.*
+src/diskio/interface/netcdf/netcdf-3.4/src/macros.make
+
+# specific binaries
+src/genesis
+src/sys/code_g
+src/sys/code_func
+src/sys/code_lib
+src/sys/code_sym
+src/sprng/checksprng
+src/sprng/timelfg
+src/sprng/timesprng
+src/sprng/*.clfg
+src/convert/convert
+src/diskio/interface/netcdf/netcdf-3.4/src/ncdump/ncdump
+src/diskio/interface/netcdf/netcdf-3.4/src/ncgen/ncgen

--- a/src/Makefile.BASE
+++ b/src/Makefile.BASE
@@ -1,7 +1,15 @@
 # Linux/BSD/Darwin defs, extracted from platform specific Makefiles
 LLIBS		=	$(LIBS) $(EXTRALIBS)
-CFLAGS		=	$(CFLAGS_IN)
-RNG_CFLAGS = -O3 -DLittleEndian -D$(MACHINE)
+CFLAGS	=	$(CFLAGS_IN)
+RNG_CFLAGS = -O3 -D$(MACHINE) # -DLittleEndian has no effect
+
+# PowerPC needs special bigendian treatment in sprng
+ifeq ($(ARCH),"powerpc")
+  RNG_CFLAGS += -DBIGENDIAN
+endif
+ifeq ($(ARCH), ppc64)
+  RNG_CFLAGS += -DBIGENDIAN
+endif
 
 #original Makefile.BASE
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -1,9 +1,16 @@
 # ----------------------------------------------------------------------
 # DEFINITIONS FOR SPECIFIC OPERATING SYSTEM AND COMPILER IN USE
 # ----------------------------------------------------------------------
-UNAME := $(shell uname)
-MACHINE=$(UNAME)
+MACHINE  ?= $(shell uname)
+ARCH     ?= $(shell uname -p)
 OS=BSD
+# TODO:
+# - detect & set matching OS based on build system
+#   (c.f. old GENESIS Makefiles)
+# - introduce PLATFORM=`uname -s` to replace MACHINE keyword
+#   in all following files;
+#   re-use MACHINE=`uname -m` to determine endianness in some
+#   cases where `uname -p` isn't working
 
 CC=@CC@
 CPP=@CPP@ -P
@@ -23,6 +30,9 @@ ifneq (@X_LIB@,)
 	XLINKPATH=-L@X_LIB@
 endif
 
+# TODO:
+# - confirm TERMCAP & TERMOPTS for other platforms
+# - create autoconf rule for that
 TERMCAP=-lncurses
 TERMOPT=-DTERMIO -DDONT_USE_SIGIO
 
@@ -32,9 +42,8 @@ TERMOPT=-DTERMIO -DDONT_USE_SIGIO
 # ----------------------------------------------------------------------
 
 # The following variable determines where GENESIS is placed by the
-# "make install" command. Substituting the full path here is preferable
-# to using `pwd`.
-INSTALLDIR	=	`pwd`/..
+# "make install" command
+INSTALLDIR ?= @prefix@/genesis
 
 # If /tmp is not big enough to contain compile-produced object files,
 # choose a different location here.
@@ -112,7 +121,7 @@ OLDCONNOBJ = $(OLDCONNDIR)/axon/axonlib.o \
 	     $(OLDCONNDIR)/sim/simconnlib.o \
 	     $(OLDCONNDIR)/tools/toolconnlib.o
 
-# 
+#
 # SPRNG -- Improved random number generation
 #
 
@@ -125,7 +134,7 @@ OLDCONNOBJ = $(OLDCONNDIR)/axon/axonlib.o \
 # The link to the users guide to installation on various platforms
 # (http://daniel.scri.fsu.edu/www/version1.0/platforms.html) may be useful
 # to address compilation problems with the SPRNG 1 version used in GENESIS.
-# 
+#
 # Note that lfg is the default and is the most tested.
 
 SPRNG_LIB = lfg
@@ -258,20 +267,20 @@ genesis: all
 #
 default: liblist
 	@rm -f kinetics/text.o kinetics/kinlib.o
-	@make -f $(MF) CC="$(CC)" TMPDIR="$(TMPDIR)" LD="$(LD)" AR="$(AR)" RANLIB="$(RANLIB)" CPP="$(CPP)" YACC="$(YACC)" LEX="$(LEX)" LEXLIB="$(LEXLIB)" OS="$(OS)" MACHINE="$(MACHINE)" INSTALLDIR="$(INSTALLDIR)" INSTALLBIN="$(INSTALLBIN)" CFLAGS_IN="$(CFLAGS) $(DISKIOFLAGS) $(SPRNG_FLAG)" IRIX_HACK="$(IRIX_HACK)" LDFLAGS="$(LDFLAGS)" SPRNG_LIB="$(SPRNG_LIB)" XLIBS="$(XLIBS)" XINCLUDE="$(XINCLUDE)" LIBS="$(LIBS)" TERMCAP="$(TERMCAP)" TERMOPT="$(TERMOPT)" MF="$(MF)" SUBDIR="$(SUBDIR)" DISKIOSUBDIR="$(DISKIOSUBDIR)" BASECODE="$(BASECODE)" OBJLIBS="$(OBJLIBS)" EXTRALIBS="$(EXTRALIBS)" XODUS="$(XODUS)"  libs genesis
+	@make -f $(MF) CC="$(CC)" TMPDIR="$(TMPDIR)" LD="$(LD)" AR="$(AR)" RANLIB="$(RANLIB)" CPP="$(CPP)" YACC="$(YACC)" LEX="$(LEX)" LEXLIB="$(LEXLIB)" OS="$(OS)" MACHINE="$(MACHINE)" ARCH="$(ARCH)" INSTALLDIR="$(INSTALLDIR)" INSTALLBIN="$(INSTALLBIN)" CFLAGS_IN="$(CFLAGS) $(DISKIOFLAGS) $(SPRNG_FLAG)" IRIX_HACK="$(IRIX_HACK)" LDFLAGS="$(LDFLAGS)" SPRNG_LIB="$(SPRNG_LIB)" XLIBS="$(XLIBS)" XINCLUDE="$(XINCLUDE)" LIBS="$(LIBS)" TERMCAP="$(TERMCAP)" TERMOPT="$(TERMOPT)" MF="$(MF)" SUBDIR="$(SUBDIR)" DISKIOSUBDIR="$(DISKIOSUBDIR)" BASECODE="$(BASECODE)" OBJLIBS="$(OBJLIBS)" EXTRALIBS="$(EXTRALIBS)" XODUS="$(XODUS)"  libs genesis
 
 #
 # Remove kinlib.o and text.o in case the last thing made had X11 stuff.
 #
 nxdefault: nxliblist
 	@rm -f kinetics/text.o kinetics/kinlib.o
-	@make -f $(MF) CC="$(CC)" TMPDIR="$(TMPDIR)" LD="$(LD)" AR="$(AR)" RANLIB="$(RANLIB)" CPP="$(CPP)" YACC="$(YACC)" LEX="$(LEX)" LEXLIB="$(LEXLIB)" OS="$(OS)" MACHINE="$(MACHINE)" INSTALLDIR="$(INSTALLDIR)" INSTALLBIN="$(INSTALLBIN)" CFLAGS_IN="$(CFLAGS) $(DISKIOFLAGS) $(SPRNG_FLAG) -DNO_X" IRIX_HACK="$(IRIX_HACK)" LDFLAGS="$(LDFLAGS)" SPRNG_LIB="$(SPRNG_LIB)" LIBS="$(LIBS)" MF="$(MF)" TERMCAP="$(TERMCAP)" TERMOPT="$(TERMOPT)" SUBDIR="$(SUBDIR)" NXSUBDIR="$(NXSUBDIR)" MINSUBDIR="$(MINSUBDIR)" DISKIOSUBDIR="$(DISKIOSUBDIR)" BASECODE="$(BASECODE)" OBJLIBS="$(OBJLIBS)" EXTRALIBS="$(EXTRALIBS)" nxlibs nxgenesis
+	@make -f $(MF) CC="$(CC)" TMPDIR="$(TMPDIR)" LD="$(LD)" AR="$(AR)" RANLIB="$(RANLIB)" CPP="$(CPP)" YACC="$(YACC)" LEX="$(LEX)" LEXLIB="$(LEXLIB)" OS="$(OS)" MACHINE="$(MACHINE)" ARCH="$(ARCH)" INSTALLDIR="$(INSTALLDIR)" INSTALLBIN="$(INSTALLBIN)" CFLAGS_IN="$(CFLAGS) $(DISKIOFLAGS) $(SPRNG_FLAG) -DNO_X" IRIX_HACK="$(IRIX_HACK)" LDFLAGS="$(LDFLAGS)" SPRNG_LIB="$(SPRNG_LIB)" LIBS="$(LIBS)" MF="$(MF)" TERMCAP="$(TERMCAP)" TERMOPT="$(TERMOPT)" SUBDIR="$(SUBDIR)" NXSUBDIR="$(NXSUBDIR)" MINSUBDIR="$(MINSUBDIR)" DISKIOSUBDIR="$(DISKIOSUBDIR)" BASECODE="$(BASECODE)" OBJLIBS="$(OBJLIBS)" EXTRALIBS="$(EXTRALIBS)" nxlibs nxgenesis
 
 mindefault: minliblist
-	@make -f $(MF) CC="$(CC)" TMPDIR="$(TMPDIR)" LD="$(LD)" AR="$(AR)" RANLIB="$(RANLIB)" CPP="$(CPP)" YACC="$(YACC)" LEX="$(LEX)" LEXLIB="$(LEXLIB)" OS="$(OS)" MACHINE="$(MACHINE)" INSTALLDIR="$(INSTALLDIR)" INSTALLBIN="$(INSTALLBIN)" CFLAGS_IN="$(CFLAGS) $(SPRNG_FLAG)" IRIX_HACK="$(IRIX_HACK)" LDFLAGS="$(LDFLAGS)" SPRNG_LIB="$(SPRNG_LIB)" LIBS="$(LIBS)" MF="$(MF)" TERMCAP="$(TERMCAP)" TERMOPT="$(TERMOPT)" SUBDIR="$(SUBDIR)" NXSUBDIR="$(NXSUBDIR)" MINSUBDIR="$(MINSUBDIR)" BASECODE="$(BASECODE)" OBJLIBS="$(OBJLIBS)" EXTRALIBS="$(EXTRALIBS)" minlibs mingenesis
+	@make -f $(MF) CC="$(CC)" TMPDIR="$(TMPDIR)" LD="$(LD)" AR="$(AR)" RANLIB="$(RANLIB)" CPP="$(CPP)" YACC="$(YACC)" LEX="$(LEX)" LEXLIB="$(LEXLIB)" OS="$(OS)" MACHINE="$(MACHINE)" ARCH="$(ARCH)" INSTALLDIR="$(INSTALLDIR)" INSTALLBIN="$(INSTALLBIN)" CFLAGS_IN="$(CFLAGS) $(SPRNG_FLAG)" IRIX_HACK="$(IRIX_HACK)" LDFLAGS="$(LDFLAGS)" SPRNG_LIB="$(SPRNG_LIB)" LIBS="$(LIBS)" MF="$(MF)" TERMCAP="$(TERMCAP)" TERMOPT="$(TERMOPT)" SUBDIR="$(SUBDIR)" NXSUBDIR="$(NXSUBDIR)" MINSUBDIR="$(MINSUBDIR)" BASECODE="$(BASECODE)" OBJLIBS="$(OBJLIBS)" EXTRALIBS="$(EXTRALIBS)" minlibs mingenesis
 
 code_g:
-	@make -f $(MF) CC="$(CC)" TMPDIR="$(TMPDIR)" LD="$(LD)" CPP="$(CPP)" YACC="$(YACC)" LEX="$(LEX)" LEXLIB="$(LEXLIB)" OS="$(OS)" MACHINE="$(MACHINE)" INSTALLDIR="$(INSTALLDIR)" INSTALLBIN="$(INSTALLBIN)" CFLAGS_IN="$(CFLAGS)" IRIX_HACK="$(IRIX_HACK)" LDFLAGS="$(LDFLAGS)" LIBS="$(LIBS)" MF="$(MF)" TERMCAP="$(TERMCAP)" TERMOPT="$(TERMOPT)" SUBDIR="$(SUBDIR)" NXSUBDIR="$(NXSUBDIR)" MINSUBDIR="$(MINSUBDIR)" BASECODE="$(BASECODE)" OBJLIBS="$(OBJLIBS)" EXTRALIBS="$(EXTRALIBS)" code_g
+	@make -f $(MF) CC="$(CC)" TMPDIR="$(TMPDIR)" LD="$(LD)" CPP="$(CPP)" YACC="$(YACC)" LEX="$(LEX)" LEXLIB="$(LEXLIB)" OS="$(OS)" MACHINE="$(MACHINE)" ARCH="$(ARCH)" INSTALLDIR="$(INSTALLDIR)" INSTALLBIN="$(INSTALLBIN)" CFLAGS_IN="$(CFLAGS)" IRIX_HACK="$(IRIX_HACK)" LDFLAGS="$(LDFLAGS)" LIBS="$(LIBS)" MF="$(MF)" TERMCAP="$(TERMCAP)" TERMOPT="$(TERMOPT)" SUBDIR="$(SUBDIR)" NXSUBDIR="$(NXSUBDIR)" MINSUBDIR="$(MINSUBDIR)" BASECODE="$(BASECODE)" OBJLIBS="$(OBJLIBS)" EXTRALIBS="$(EXTRALIBS)" code_g
 
 nxgenesis: code_g nxdefault
 nxall: code_g nxdefault


### PR DESCRIPTION
Fixes to Makefile.{in,BASE}:
- INSTALLDIR is now using @prefix@ variable from ./configure
- Determine endianness for RNG_CFLAGS from `uname -p`
  (should help on PPC machines and the like)

Also, adjusted .gitignore to deal with clutter from building
