### PR TITLE
Bigendian should also affect CFLAGS

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,14 @@
+# TODO: Makefile.in
+# - detect & set matching OS based on build system
+#   (c.f. old GENESIS Makefiles)
+# - introduce PLATFORM=`uname -s` to replace MACHINE keyword
+#   in all following files;
+#   re-use MACHINE=`uname -m` to determine endianness in some
+#   cases where `uname -p` isn't working
+#
+# - confirm TERMCAP & TERMOPTS for other platforms
+#   -> create autoconf rule for that
+#
+# - autoconf provides WORDS_BIGENDIAN via AC_C_BIGENDIAN
+#   -> change throughout sprng & in Xodus/Widg/xgifload.c
+

--- a/src/Makefile.BASE
+++ b/src/Makefile.BASE
@@ -4,11 +4,15 @@ CFLAGS	=	$(CFLAGS_IN)
 RNG_CFLAGS = -O3 -D$(MACHINE) # -DLittleEndian has no effect
 
 # PowerPC needs special bigendian treatment in sprng
-ifeq ($(ARCH),"powerpc")
+# TODO:
+# - autoconf provides WORD_BIGENDIAN via AC_C_BIGENDIAN
+ifeq ($(ARCH), powerpc)
   RNG_CFLAGS += -DBIGENDIAN
+  CFLAGS += -DBIGENDIAN
 endif
 ifeq ($(ARCH), ppc64)
   RNG_CFLAGS += -DBIGENDIAN
+  CFLAGS += -DBIGENDIAN
 endif
 
 #original Makefile.BASE


### PR DESCRIPTION
Added BIGENDIAN to CFLAGS for PPC-based systems, as at least in
Xodus/Widg/xgifload.c there are different codepaths related to
endianness
