### PR TITLE
Fixed broken netcdf support due to legacy libs

### DIFF
--- a/src/Makefile.BASE
+++ b/src/Makefile.BASE
@@ -10,6 +10,7 @@ RNG_CFLAGS ?= -O3 -D$(MACHINE) # -DLittleEndian has no effect
 ifeq ($(ARCH), powerpc)
   RNG_CFLAGS += -DBIGENDIAN
   CFLAGS += -DBIGENDIAN
+  LIBS += $(XPRELIBS)    # X11 backwards compatibility on 10.3.9
 endif
 ifeq ($(ARCH), ppc64)
   RNG_CFLAGS += -DBIGENDIAN

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -24,11 +24,19 @@ YACC=@YACC@
 LEX=@LEX@
 
 LEXLIB=@LEXLIB@
-LIBS=$(LEXLIB) -lm @X_PRE_LIBS@
+LIBS=$(LEXLIB) -lm
 XINCLUDE=-I@X_INC@
 ifneq (@X_LIB@,)
 	XLINKPATH=-L@X_LIB@
 endif
+
+# X11's ICE, SM libraries break netcdf on OSX
+# (needed for backward compatibility?)
+XPRELIBS=@X_PRE_LIBS@
+ifneq ($(MACHINE), Darwin)
+	LIBS += $(XPRELIBS)
+endif
+
 
 # TODO:
 # - confirm TERMCAP & TERMOPTS for other platforms
@@ -99,11 +107,11 @@ DISKIOFLAGS  = $(NETCDFFLAGS) \
 # more information.  NOTE: *only* uncomment the netCDF definitions below
 # if diskio support is included above.
 
-#NETCDFSUBDIR = netcdf
-#NETCDFOBJ = \
-#	$(DISKIODIR)/interface/$(NETCDFSUBDIR)/netcdflib.o \
-#	$(DISKIODIR)/interface/$(NETCDFSUBDIR)/netcdf-3.4/src/libsrc/libnetcdf.a
-#NETCDFFLAGS = -Dnetcdf
+NETCDFSUBDIR = netcdf
+NETCDFOBJ = \
+	$(DISKIODIR)/interface/$(NETCDFSUBDIR)/netcdflib.o \
+	$(DISKIODIR)/interface/$(NETCDFSUBDIR)/netcdf-3.4/src/libsrc/libnetcdf.a
+NETCDFFLAGS = -Dnetcdf
 
 #
 # oldconn --- GENESIS 1.4 network connection compatibility library


### PR DESCRIPTION
Autoconf filled in LIBS=@X_PRE_LIBS@ with `-lSM -lICE` which breaks
netcdf compilation on at least MacOS X 10.8 and later. This flag is
now ignored on Intel-Darwin platforms.
